### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Running without a warrior
 -------------------------
 To run this outside the warrior, clone this repository, cd into its directory and run:
 
-    pip install seesaw
+    pip install --upgrade seesaw
     ./get-wget-lua.sh
 
 then start downloading with:
@@ -32,9 +32,9 @@ For more options, run:
 
     run-pipeline --help
 
-If you don't have root access and/or your version of pip is very old, you can replace "pip install seesaw" with:
+If you don't have root access and/or your version of pip is very old, you can replace "pip install --upgrade seesaw" with:
 
-    wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py ; python get-pip.py --user ; ~/.local/bin/pip install --user seesaw
+    wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py ; python get-pip.py --user ; ~/.local/bin/pip install --upgrade --user seesaw
 
 so that pip and seesaw are installed in your home, then run
 
@@ -56,8 +56,8 @@ Distribution-specific setup
 ### For Debian/Ubuntu:
 
     adduser --system --group --shell /bin/bash archiveteam
-    apt-get install -y git-core libgnutls-dev lua5.1 liblua5.1-0 liblua5.1-0-dev screen python-dev python-pip bzip2 zlib1g-dev
-    pip install seesaw
+    apt-get update && apt-get install -y git-core libgnutls-dev lua5.1 liblua5.1-0 liblua5.1-0-dev screen python-dev python-pip bzip2 zlib1g-dev
+    pip install --upgrade seesaw
     su -c "cd /home/archiveteam; git clone https://github.com/ArchiveTeam/{{REPO_NAME}}.git; cd {{REPO_NAME}}; ./get-wget-lua.sh" archiveteam
     screen su -c "cd /home/archiveteam/{{REPO_NAME}}/; run-pipeline pipeline.py --concurrent 2 --address '127.0.0.1' YOURNICKHERE" archiveteam
     [... ctrl+A D to detach ...]
@@ -69,13 +69,13 @@ Wget-lua is also available on [ArchiveTeam's PPA](https://launchpad.net/~archive
 Ensure that you have the CentOS equivalent of bzip2 installed as well. You might need the EPEL repository to be enabled.
 
     yum -y install gnutls-devel lua-devel python-pip zlib-devel
-    pip install seesaw
+    pip install --upgrade seesaw
     [... pretty much the same as above ...]
 
 ### For openSUSE:
 
     zypper install liblua5_1 lua51 lua51-devel screen python-pip libgnutls-devel bzip2 python-devel gcc make
-    pip install seesaw
+    pip install --upgrade seesaw
     [... pretty much the same as above ...]
 
 ### For OS X:
@@ -83,7 +83,7 @@ Ensure that you have the CentOS equivalent of bzip2 installed as well. You might
 You need Homebrew. Ensure that you have the OS X equivalent of bzip2 installed as well.
 
     brew install python lua gnutls
-    pip install seesaw
+    pip install --upgrade seesaw
     [... pretty much the same as above ...]
 
 **There is a known issue with some packaged versions of rsync. If you get errors during the upload stage, {{REPO_NAME}} will not work with your rsync version.**
@@ -98,7 +98,7 @@ Ensure that you have the Arch equivalent of bzip2 installed as well.
 
 1. Make sure you have `python2-pip` installed.
 2. Install [https://aur.archlinux.org/packages/wget-lua/](the wget-lua package from the AUR). 
-3. Run `pip2 install seesaw`.
+3. Run `pip2 install --upgrade seesaw`.
 4. Modify the run-pipeline script in seesaw to point at `#!/usr/bin/python2` instead of `#!/usr/bin/python`.
 5. `useradd --system --group users --shell /bin/bash --create-home archiveteam`
 6. `screen su -c "cd /home/archiveteam/{{REPO_NAME}}/; run-pipeline pipeline.py --concurrent 2 --address '127.0.0.1' YOURNICKHERE" archiveteam`


### PR DESCRIPTION
Adds an `--upgrade` flag to all `pip install` commands, so as to make sure that the latest version of `seesaw` is always installed.

This is necessary for the install instructions to work correctly on a system that has run an older pipeline in the past.

This pull request was also made at ArchiveTeam/blogger-discovery#1, but this version also adds `apt-get update` before the `apt-get install` command, which is necessary to make sure no 404s are encountered due to outdated package lists.