### PR TITLE
Fix broken syntax, minor changes

### DIFF
--- a/README.wget-at.md
+++ b/README.wget-at.md
@@ -1,10 +1,8 @@
-{{REPO_NAME}}
-=============
+# {{REPO_NAME}}
 
 More information about the archiving project can be found on the ArchiveTeam wiki: [{{PROJECT_NAME}}](https://wiki.archiveteam.org/index.php?title={{PROJECT_NAME}})
 
-Setup instructions
-=========================
+## Setup instructions
 
 ### General instructions
 
@@ -25,21 +23,21 @@ We strongly encourage you to join the IRC channel associated with this project i
 
 #### Archive Team Warrior (recommended for most users)
 
-This and other archiving projects can easily be run using the [Archive Team Warrior](https://wiki.archiveteam.org/index.php/ArchiveTeam_Warrior) virtual machine. Follow the [instructions on the Archive Team wiki](https://wiki.archiveteam.org/index.php/ArchiveTeam_Warrior) for installing the Warrior, and from the web interface running at http://localhost:8001/, enter the nickname that you want to be shown as on the tracker. You don't need to register it, just pick a nickname you like. Then, select the "{{PROJECT_NAME}}" project in the Warrior interface.
+This and other archiving projects can easily be run using the [Archive Team Warrior](https://wiki.archiveteam.org/index.php/ArchiveTeam_Warrior) virtual machine. Follow the [instructions on the Archive Team wiki](https://wiki.archiveteam.org/index.php/ArchiveTeam_Warrior) for installing the Warrior, and from the web interface running at `http://localhost:8001/`, enter the nickname that you want to be shown as on the tracker. There is no registration, just pick a nickname you like. Then, select the `{{PROJECT_NAME}}` project in the Warrior interface.
 
 #### Project-specific Docker container (for more advanced users)
 
-Alternatively, more advanced users can also run projects using Docker. While users of the Warrior can switch between projects using a web interface, Docker containers are specific to each project. However, while the Warrior supports a maximum of 6 concurrent items, the Docker container supports a maximum of 20 concurrent items. The instructions below are a short overview. For more information and detailed explanations of the commands, follow the follow the [Docker instructions on the Archive Team wiki](https://wiki.archiveteam.org/index.php/Running_Archive_Team_Projects_with_Docker).
+Alternatively, more advanced users can also run projects using Docker. While users of the Warrior can switch between projects using a web interface, Docker containers are specific to each project. However, while the Warrior supports a maximum of 6 concurrent items, a Docker container supports a maximum of 20 concurrent items. The instructions below are a short overview. For more information and detailed explanations of the commands, follow the follow the [Docker instructions on the Archive Team wiki](https://wiki.archiveteam.org/index.php/Running_Archive_Team_Projects_with_Docker).
 
-It is advised to use watchtower to automatically update the project:
+It is advised to use [Watchtower](https://github.com/containrrr/watchtower) to automatically update the project container:
 
     docker run -d --name watchtower --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --label-enable --cleanup --interval 3600
 
-after which the project can be run:
+after which the project container can be run:
 
-    docker run -d -name archiveteam --label=com.centurylinklabs.watchtower.enable=true --restart=unless-stopped atdr.meo.ws/archiveteam/{{REPO_NAME}} --concurrent 1 YOURNICKHERE
+    docker run -d --name archiveteam --label=com.centurylinklabs.watchtower.enable=true --restart=unless-stopped atdr.meo.ws/archiveteam/{{REPO_NAME}} --concurrent 1 YOURNICKHERE
 
-Be sure to replace `YOURNICKHERE` with the nickname that you want to be shown as on the tracker. You don't need to register it, just pick a nickname you like.
+Be sure to replace `YOURNICKHERE` with the nickname that you want to be shown as on the tracker. There is no registration, just pick a nickname you like.
 
 ### Issues in the code
 

--- a/README.wget-lua.md
+++ b/README.wget-lua.md
@@ -1,25 +1,22 @@
-{{REPO_NAME}}
-=============
+# {{REPO_NAME}}
 
 More information about the archiving project can be found on the ArchiveTeam wiki: [{{PROJECT_NAME}}](http://archiveteam.org/index.php?title={{PROJECT_NAME}})
 
-Setup instructions
-=========================
+## Setup instructions
 
-Be sure to replace `YOURNICKHERE` with the nickname that you want to be shown as, on the tracker. You don't need to register it, just pick a nickname you like.
+Be sure to replace `YOURNICKHERE` with the nickname that you want to be shown as, on the tracker. There is no registration, just pick a nickname you like.
 
-In most of the below cases, there will be a web interface running at http://localhost:8001/. If you don't know or care what this is, you can just ignore it—otherwise, it gives you a fancy view of what's going on.
+In most of the below cases, there will be a web interface running at `http://localhost:8001/`. If you don't know or care what this is, you can just ignore it. Otherwise, it gives you a fancy view of what's going on.
 
 **If anything goes wrong while running the commands below, please scroll down to the bottom of this page. There's troubleshooting information there.**
 
-Running with a warrior
--------------------------
+### Running with a warrior
 
 Follow the [instructions on the ArchiveTeam wiki](http://archiveteam.org/index.php?title=Warrior) for installing the Warrior, and select the "{{PROJECT_NAME}}" project in the Warrior interface.
 
-Running without a warrior
--------------------------
-To run this outside the warrior, clone this repository, cd into its directory and run:
+### Running without a warrior
+
+To run this outside the warrior, clone this repository, change into its directory and run:
 
     pip install --upgrade seesaw
     ./get-wget-lua.sh
@@ -32,18 +29,19 @@ For more options, run:
 
     run-pipeline --help
 
-If you don't have root access and/or your version of pip is very old, you can replace "pip install --upgrade seesaw" with:
+If you don't have root access and/or your version of pip is very old, you can replace `pip install --upgrade seesaw` with:
 
-    wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py ; python get-pip.py --user ; ~/.local/bin/pip install --upgrade --user seesaw
+    wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+    python get-pip.py --user
+    ~/.local/bin/pip install --upgrade --user seesaw
 
 so that pip and seesaw are installed in your home, then run
 
     ~/.local/bin/run-pipeline pipeline.py --concurrent 2 YOURNICKHERE
 
-Running multiple instances on different IPs
--------------------------------------------
+### Running multiple instances on different IPs
 
-This feature requires seesaw version 0.0.16 or greater. Use `pip install --upgrade seesaw` to upgrade.
+This feature requires `seesaw` version 0.0.16 or greater. Use `pip install --upgrade seesaw` to upgrade.
 
 Use the `--context-value` argument to pass in `bind_address=123.4.5.6` (replace the IP address with your own).
 
@@ -51,9 +49,9 @@ Example of running 2 threads, no web interface, and Wget binding of IP address:
 
     run-pipeline pipeline.py --concurrent 2 YOURNICKHERE --disable-web-server --context-value bind_address=123.4.5.6
 
-Distribution-specific setup
--------------------------
-### For Debian/Ubuntu:
+### Distribution-specific setup
+
+#### For Debian/Ubuntu:
 
     adduser --system --group --shell /bin/bash archiveteam
     apt-get update && apt-get install -y git-core libgnutls-dev lua5.1 liblua5.1-0 liblua5.1-0-dev screen python-dev python-pip bzip2 zlib1g-dev flex autoconf
@@ -70,69 +68,68 @@ In __Debian Jessie, Ubuntu 18.04 Bionic and above__, the `libgnutls-dev` package
 
 Wget-lua is also available on [ArchiveTeam's PPA](https://launchpad.net/~archiveteam/+archive/wget-lua) for Ubuntu.
 
-
-And you may also need to update your Python's warcio if you find screen detaching immediately after running the job in Ubuntu 18.04 Bionic and above:
+And you may also need to update your Python's `warcio` if you find screen detaching immediately after running the job in Ubuntu 18.04 Bionic and above:
 
     pip install warcio --upgrade
 
-### For CentOS:
+#### For CentOS:
 
-Ensure that you have the CentOS equivalent of bzip2 installed as well. You will the EPEL repository to be enabled.
+Ensure that you have the CentOS equivalent of `bzip2` installed as well. You will the EPEL repository to be enabled.
 
     yum -y install autoconf automake flex gnutls-devel lua-devel python-pip zlib-devel
     pip install --upgrade seesaw
     [... pretty much the same as above ...]
 
-### For openSUSE:
+#### For openSUSE:
 
     zypper install liblua5_1 lua51 lua51-devel screen python-pip libgnutls-devel bzip2 python-devel gcc make
     pip install --upgrade seesaw
     [... pretty much the same as above ...]
 
-### For OS X:
+#### For macOS:
 
-You need Homebrew. Ensure that you have the OS X equivalent of bzip2 installed as well.
+You need Homebrew. Ensure that you have the macOS equivalent of `bzip2` installed as well.
 
     brew install python lua gnutls
     pip install --upgrade seesaw
     [... pretty much the same as above ...]
 
-**There is a known issue with some packaged versions of rsync. If you get errors during the upload stage, {{REPO_NAME}} will not work with your rsync version.**
+**There is a known issue with some packaged versions of Rsync. If you get errors during the upload stage, {{REPO_NAME}} will not work with your Rsync version.**
 
 This supposedly fixes it:
 
     alias rsync=/usr/local/bin/rsync
 
-### For Arch Linux:
+#### For Arch Linux:
 
-Ensure that you have the Arch equivalent of bzip2 installed as well.
+Ensure that you have the Arch equivalent of `bzip2` installed as well.
 
 1. Make sure you have `python2-pip` installed.
-2. Install [the wget-lua package from the AUR](https://aur.archlinux.org/packages/wget-lua/). 
+2. Install [the `wget-lua` package from the AUR](https://aur.archlinux.org/packages/wget-lua/). 
 3. Run `pip2 install --upgrade seesaw`.
 4. Modify the run-pipeline script in seesaw to point at `#!/usr/bin/python2` instead of `#!/usr/bin/python`.
 5. `useradd --system --group users --shell /bin/bash --create-home archiveteam`
 6. `screen su -c "cd /home/archiveteam/{{REPO_NAME}}/; run-pipeline pipeline.py --concurrent 2 --address '127.0.0.1' YOURNICKHERE" archiveteam`
 
-### For Alpine Linux:
+#### For Alpine Linux:
 
     apk add lua5.1 git python bzip2 bash rsync gcc libc-dev lua5.1-dev zlib-dev gnutls-dev autoconf flex make
     python -m ensurepip
     pip install -U seesaw
     git clone https://github.com/ArchiveTeam/{{REPO_NAME}}
-    cd {{REPO_NAME}}; ./get-wget-lua.sh
+    cd {{REPO_NAME}}
+    ./get-wget-lua.sh
     run-pipeline pipeline.py --concurrent 2 --address '127.0.0.1' YOURNICKHERE
 
-### For FreeBSD:
+#### For FreeBSD:
 
-Honestly, I have no idea. `./get-wget-lua.sh` supposedly doesn't work due to differences in the `tar` that ships with FreeBSD. Another problem is the apparent absence of Lua 5.1 development headers. If you figure this out, please do let us know on IRC (irc.hackint.org #archiveteam).
+Honestly, I have no idea. `./get-wget-lua.sh` supposedly doesn't work due to differences in the `tar` that ships with FreeBSD. Another problem is the apparent absence of Lua 5.1 development headers. If you figure this out, please do let us know on IRC ([irc.hackint.org #archiveteam](https://webirc.hackint.org/#irc://irc.hackint.org/#archiveteam)).
 
-Troubleshooting
-=========================
+## Troubleshooting
 
 Broken? These are some of the possible solutions:
 
-### wget-lua was not successfully built
+### `wget-lua` was not successfully built
 
 If you get errors about `wget.pod` or something similar, the documentation failed to compile - wget-lua, however, compiled fine. Try this:
 
@@ -142,19 +139,19 @@ If you get errors about `wget.pod` or something similar, the documentation faile
 
 The `get-wget-lua.tmp` name may be inaccurate. If you have a folder with a similar but different name, use that instead and please let us know on IRC what folder name you had!
 
-Optionally, if you know what you're doing, you may want to use wgetpod.patch.
+Optionally, if you know what you're doing, you may want to use `wgetpod.patch`.
 
-### Problem with gnutls or openssl during get-wget-lua
+### Problem with GnuTLS or OpenSSL during get-wget-lua
 
-Please ensure that gnutls-dev(el) and openssl-dev(el) are installed.
+Please ensure that `gnutls-dev(el)` and `openssl-dev(el)` are installed.
 
-### ImportError: No module named seesaw
+### `ImportError: No module named seesaw`
 
 If you're sure that you followed the steps to install `seesaw`, permissions on your module directory may be set incorrectly. Try the following:
 
     chmod o+rX -R /usr/local/lib/python2.7/dist-packages
 
-### run-pipeline: command not found
+### `run-pipeline: command not found`
 
 Install `seesaw` using `pip2` instead of `pip`.
 

--- a/README.wpull.md
+++ b/README.wpull.md
@@ -1,25 +1,22 @@
-{{REPO_NAME}}
-=============
+# {{REPO_NAME}}
 
 More information about the archiving project can be found on the ArchiveTeam wiki: [{{PROJECT_NAME}}](http://archiveteam.org/index.php?title={{PROJECT_NAME}})
 
-Setup instructions
-=========================
+## Setup instructions
 
-Be sure to replace `YOURNICKHERE` with the nickname that you want to be shown as, on the tracker. You don't need to register it, just pick a nickname you like.
+Be sure to replace `YOURNICKHERE` with the nickname that you want to be shown as, on the tracker. There is no registration, just pick a nickname you like.
 
-In most of the below cases, there will be a web interface running at http://localhost:8001/. If you don't know or care what this is, you can just ignore it—otherwise, it gives you a fancy view of what's going on.
+In most of the below cases, there will be a web interface running at `http://localhost:8001/`. If you don't know or care what this is, you can just ignore it—otherwise, it gives you a fancy view of what's going on.
 
 **If anything goes wrong while running the commands below, please scroll down to the bottom of this page. There's troubleshooting information there.**
 
-Running with a warrior
--------------------------
+### Running with a warrior
 
 Follow the [instructions on the ArchiveTeam wiki](http://archiveteam.org/index.php?title=Warrior) for installing the Warrior, and select the "{{PROJECT_NAME}}" project in the Warrior interface.
 
-Running without a warrior
--------------------------
-To run this outside the warrior, clone this repository, cd into its directory and run:
+### Running without a warrior
+
+To run this outside the warrior, clone this repository, change into its directory and run:
 
     pip install --upgrade seesaw
 
@@ -37,18 +34,19 @@ For more options, run:
 
     run-pipeline --help
 
-If you don't have root access and/or your version of pip is very old, you can replace "pip install --upgrade seesaw" with:
+If you don't have root access and/or your version of Pip is very old, you can replace `pip install --upgrade seesaw with:
 
-    wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py ; python get-pip.py --user ; ~/.local/bin/pip install --user seesaw
+    wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+    python get-pip.py --user
+    ~/.local/bin/pip install --user seesaw
 
-so that pip and seesaw are installed in your home, then run
+so that `pip` and `seesaw` are installed in your home, then run
 
     ~/.local/bin/run-pipeline pipeline.py --concurrent 2 YOURNICKHERE
 
-Running multiple instances on different IPs
--------------------------------------------
+### Running multiple instances on different IPs
 
-This feature requires seesaw version 0.0.16 or greater. Use `pip install --upgrade seesaw` to upgrade.
+This feature requires `seesaw` version 0.0.16 or greater. Use `pip install --upgrade seesaw` to upgrade.
 
 Use the `--context-value` argument to pass in `bind_address=123.4.5.6` (replace the IP address with your own).
 
@@ -56,9 +54,9 @@ Example of running 2 threads, no web interface, and Wget binding of IP address:
 
     run-pipeline pipeline.py --concurrent 2 YOURNICKHERE --disable-web-server --context-value bind_address=123.4.5.6
 
-Distribution-specific setup
--------------------------
-### For Debian/Ubuntu:
+### Distribution-specific setup
+
+#### For Debian/Ubuntu:
 
     adduser --system --group --shell /bin/bash archiveteam
     apt-get update && install -y git-core libgnutls-dev screen python-dev python-pip bzip2 zlib1g-dev unzip
@@ -68,24 +66,23 @@ Distribution-specific setup
     screen su -c "cd /home/archiveteam/{{REPO_NAME}}/; run-pipeline pipeline.py --concurrent 2 --address '127.0.0.1' YOURNICKHERE" archiveteam
     [... ctrl+A D to detach ...]
 
+#### For CentOS:
 
-### For CentOS:
-
-Ensure that you have the CentOS equivalent of bzip2 installed as well. You might need the EPEL repository to be enabled.
+Ensure that you have the CentOS equivalent of `bzip2` installed as well. You will the EPEL repository to be enabled.
 
     yum -y install gnutls-devel python-pip zlib-devel unzip
     pip install --upgrade seesaw
     [... pretty much the same as above ...]
 
-### For openSUSE:
+#### For openSUSE:
 
     zypper install screen python-pip libgnutls-devel bzip2 python-devel gcc make unzip
     pip install --upgrade seesaw
     [... pretty much the same as above ...]
 
-### For OS X:
+#### For macOS:
 
-You need Homebrew. Ensure that you have the OS X equivalent of bzip2 installed as well.
+You need Homebrew. Ensure that you have the macOS equivalent of `bzip2` installed as well.
 
     brew install python gnutls unzip
     pip install --upgrade seesaw
@@ -97,9 +94,9 @@ This supposedly fixes it:
 
     alias rsync=/usr/local/bin/rsync
 
-### For Arch Linux:
+#### For Arch Linux:
 
-Ensure that you have the Arch equivalent of bzip2 installed as well.
+Ensure that you have the Arch equivalent of `bzip2` installed as well.
 
 1. Make sure you have `python2-pip` installed.
 2. Run `pip2 install seesaw`.
@@ -109,12 +106,11 @@ Ensure that you have the Arch equivalent of bzip2 installed as well.
 6. `su -c "cd /home/archiveteam/{{REPO_NAME}}/; wget {{WPULL_DOWNLOAD_URL}}; unzip {{WPULL_DOWNLOAD_FILENAME}}; chmod +x ./wpull" archiveteam`
 7. `screen su -c "cd /home/archiveteam/{{REPO_NAME}}/; run-pipeline pipeline.py --concurrent 2 --address '127.0.0.1' YOURNICKHERE" archiveteam`
 
-### For FreeBSD:
+#### For FreeBSD:
 
-Nothing specific here. If not so, please do let us know on IRC (irc.hackint.org #archiveteam).
+Nothing specific here. If not so, please do let us know on IRC ([irc.hackint.org #archiveteam](https://webirc.hackint.org/#irc://irc.hackint.org/#archiveteam)).
 
-Troubleshooting
-=========================
+## Troubleshooting
 
 Broken? These are some of the possible solutions:
 
@@ -122,17 +118,17 @@ Broken? These are some of the possible solutions:
 
 If you have trouble getting Wpull running, please see http://wpull.readthedocs.org/en/master/install.html.
 
-### Problem with gnutls or openssl during building
+### Problem with GnuTLS or OpenSSL during building
 
-Please ensure that gnutls-dev(el) and openssl-dev(el) are installed.
+Please ensure that `gnutls-dev(el)` and `openssl-dev(el)` are installed.
 
-### ImportError: No module named seesaw
+### `ImportError: No module named seesaw`
 
 If you're sure that you followed the steps to install `seesaw`, permissions on your module directory may be set incorrectly. Try the following:
 
     chmod o+rX -R /usr/local/lib/python2.7/dist-packages
 
-### run-pipeline: command not found
+### `run-pipeline: command not found`
 
 Install `seesaw` using `pip2` instead of `pip`.
 


### PR DESCRIPTION
I "broke" the command by doing `-name` instead of `--name`. I don't know if this will make it error, but just to be sure, I fixed it.

Along with some other minor changes:

- "You don't need to register it" still implies a registration is available. Changed it to "There is no registration."
- Consistent heading syntax (using `#` like other headings)
- Use `\`` instead of `"`
- Link to Watchtower, and case fix on it
- Add "container" before "project" to refer to the container, to refer the container and not the project.